### PR TITLE
refactor: Remove parameter from `output_message`

### DIFF
--- a/lib/wakaba.rb
+++ b/lib/wakaba.rb
@@ -8,8 +8,8 @@ module Wakaba
 
   # propose a solution in Japanese
   module ExceptionJp
-    def output_message(error_type)
-      case error_type
+    def output_message
+      case self
       when NoMethodError
         <<~SUGGESTION
 
@@ -73,9 +73,8 @@ module Wakaba
 
     def message
       if self
-        error_type = self
         puts "\e[31m#{self}\e[0m"
-        output_message(error_type)
+        output_message
       else
         super
       end

--- a/spec/wakaba_spec.rb
+++ b/spec/wakaba_spec.rb
@@ -3,26 +3,26 @@
 RSpec.describe Wakaba do
   it 'Expect a NameError message' do
     error = NameError.new(NameError, 'argument')
-    expect(error.output_message(error)).to include('argumentってタイポしてにゃい？')
+    expect(error.message).to include('argumentってタイポしてにゃい？')
   end
 
   it 'Expect a NoMethodError message' do
     error = NoMethodError.new(NoMethodError, 'argument')
-    expect(error.output_message(error)).to include('argumentという名前のメソッドは存在するかにゃ？')
+    expect(error.message).to include('argumentという名前のメソッドは存在するかにゃ？')
   end
 
   it 'Expect a TypeError message' do
     error = TypeError.new
-    expect(error.output_message(error)).to include('期待しにゃい型がメソッドの引数に渡されているﾆｬｰ')
+    expect(error.message).to include('期待しにゃい型がメソッドの引数に渡されているﾆｬｰ')
   end
 
   it 'Expect a ArgumentError message' do
     error = ArgumentError.new
-    expect(error.output_message(error)).to include('引数の数が違うﾆｬﾝ？')
+    expect(error.message).to include('引数の数が違うﾆｬﾝ？')
   end
 
   it 'Expect a ZeroDivisionError message' do
     error = ZeroDivisionError.new
-    expect(error.output_message(error)).to include('0で除算するとこのエラーが発生するニャン')
+    expect(error.message).to include('0で除算するとこのエラーが発生するニャン')
   end
 end


### PR DESCRIPTION
The all information it needs can be taken from `self`.
Also, `message` should be the interface for testing.